### PR TITLE
Fix linkedit error on OS X with newer versions of Boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ catkin_package(
   INCLUDE_DIRS include
   )
 
-find_package(Boost REQUIRED date_time thread)
+find_package(Boost REQUIRED date_time system thread)
 include_directories(${Boost_INCLUDE_DIR})
 
 include_directories(include)


### PR DESCRIPTION
When building `random_numbers` on OS X with Boost 1.53.0 I get:

```
==> Processing catkin package: 'random_numbers'
==> Creating build directory: 'build_isolated/random_numbers'
==> Building with env: '/Users/william/moveit_ws/install_isolated/env.sh'
==> cmake /Users/william/moveit_ws/src/random_numbers -DCATKIN_DEVEL_PREFIX=/Users/william/moveit_ws/devel_isolated/random_numbers -DCMAKE_INSTALL_PREFIX=/Users/william/moveit_ws/install_isolated
-- The C compiler identification is Clang 4.2.0
-- The CXX compiler identification is Clang 4.2.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Using CATKIN_DEVEL_PREFIX: /Users/william/moveit_ws/devel_isolated/random_numbers
-- Using CMAKE_PREFIX_PATH: /Users/william/moveit_ws/install_isolated
-- This workspace overlays: /Users/william/moveit_ws/install_isolated
-- Found PythonInterp: /usr/bin/python (found version "2.7.2")
-- Found PY_em: /Library/Python/2.7/site-packages/em.pyc
-- Found gtest: gtests will be built
-- Using CATKIN_TEST_RESULTS_DIR: /Users/william/moveit_ws/build_isolated/random_numbers/test_results
-- catkin 0.5.65
WARNING: 'catkin' should be listed as a buildtool dependency in the package.xml (instead of build dependency)
-- Boost version: 1.53.0
-- Found the following Boost libraries:
--   date_time
--   thread
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/william/moveit_ws/build_isolated/random_numbers
==> make -j4 -l4 in '/Users/william/moveit_ws/build_isolated/random_numbers'
Scanning dependencies of target random_numbers
[100%] Building CXX object CMakeFiles/random_numbers.dir/src/random_numbers.cpp.o
Linking CXX shared library /Users/william/moveit_ws/devel_isolated/random_numbers/lib/librandom_numbers.dylib
Undefined symbols for architecture x86_64:
  "boost::system::system_category()", referenced from:
      ___cxx_global_var_init3 in random_numbers.cpp.o
      boost::thread_exception::thread_exception(int, char const*) in random_numbers.cpp.o
  "boost::system::generic_category()", referenced from:
      ___cxx_global_var_init1 in random_numbers.cpp.o
      ___cxx_global_var_init2 in random_numbers.cpp.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [/Users/william/moveit_ws/devel_isolated/random_numbers/lib/librandom_numbers.dylib] Error 1
make[1]: *** [CMakeFiles/random_numbers.dir/all] Error 2
make: *** [all] Error 2
Traceback (most recent call last):
  File "./src/catkin/bin/../python/catkin/builder.py", line 658, in build_workspace_isolated
    number=index + 1, of=len(ordered_packages)
  File "./src/catkin/bin/../python/catkin/builder.py", line 443, in build_package
    install, jobs, force_cmake, quiet, last_env, cmake_args, make_args
  File "./src/catkin/bin/../python/catkin/builder.py", line 297, in build_catkin_package
    run_command(make_cmd, build_dir, quiet)
  File "./src/catkin/bin/../python/catkin/builder.py", line 186, in run_command
    raise subprocess.CalledProcessError(proc.returncode, ' '.join(cmd))
CalledProcessError: Command '/Users/william/moveit_ws/install_isolated/env.sh make -j4 -l4' returned non-zero exit status 2
<== Failed to process package 'random_numbers':
  Command '/Users/william/moveit_ws/install_isolated/env.sh make -j4 -l4' returned non-zero exit status 2

Reproduce this error by running:
==> /Users/william/moveit_ws/install_isolated/env.sh make -j4 -l4

Command failed, exiting.
```

Adding the `system` element to the `Boost` components being found fixes this.
