### PR TITLE
Added ability to specify random number generator seed for stochastic behavior

### DIFF
--- a/include/random_numbers/random_numbers.h
+++ b/include/random_numbers/random_numbers.h
@@ -57,6 +57,9 @@ public:
   
   /** \brief Constructor. Always sets a "random" random seed */
   RandomNumberGenerator(void);
+
+  /** \brief Constructor. Allow a seed to be specified for deterministic behaviour */
+  RandomNumberGenerator(boost::uint32_t seed);
   
   /** \brief Generate a random real between 0 and 1 */
   double uniform01(void)

--- a/src/random_numbers.cpp
+++ b/src/random_numbers.cpp
@@ -74,6 +74,15 @@ random_numbers::RandomNumberGenerator::RandomNumberGenerator(void) : generator_(
 {
 }
 
+random_numbers::RandomNumberGenerator::RandomNumberGenerator(boost::uint32_t seed)
+                                                                   : generator_(seed),
+                                                                     uniDist_(0, 1),
+                                                                     normalDist_(0, 1),
+                                                                     uni_(generator_, uniDist_),
+                                                                     normal_(generator_, normalDist_)
+{
+}
+
 // From: "Uniform Random Rotations", Ken Shoemake, Graphics Gems III,
 //       pg. 124-132
 void random_numbers::RandomNumberGenerator::quaternion(double value[4])


### PR DESCRIPTION
I am using this for benchmarking and I want to set random joint values but get the same sequence every time, so I set the seed to some unchanging int.
