### PR TITLE
remove deprecated ament_target_dependencies()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,13 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15)
 project(random_numbers)
 
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(Boost REQUIRED date_time random thread)
+
 
 include_directories(include)
 
@@ -15,7 +15,7 @@ add_library(${PROJECT_NAME} SHARED
   src/random_numbers.cpp
 )
 
-ament_target_dependencies(${PROJECT_NAME} Boost)
+
 ament_export_libraries(${PROJECT_NAME})
 ament_export_dependencies(Boost)
 ament_export_include_directories(include)


### PR DESCRIPTION
removed unnecessary  and deprecated  ament_target_dependencies() 
fix cmake 3.5 deprecation
set ros2 CXX standard to CXX_17